### PR TITLE
Fix date filter crash when no matches found

### DIFF
--- a/app.py
+++ b/app.py
@@ -178,6 +178,10 @@ pair = df[
 ].copy()
 pair = pair.apply(orient, axis=1, left=p1)
 
+if pair.empty:
+    st.info("No matches found between selected players.")
+    st.stop()
+
 
 # ── DATE FILTER ──────────────────────────────────────────────────────
 min_date = pair["Date"].min()


### PR DESCRIPTION
## Summary
- handle cases where no matches exist for selected players

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688d17255c248329af3ad5a2c2877527